### PR TITLE
Support optional callback in addition to sendFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# ATTENTION, THIS IS JUST A TEMPORARY FORK
+
+I just needed to use callbacks instead of being limited to res.sendFile as I 
+use React server side rendering instead of a static index.html file.
+
 # express-history-api-fallback
 A tiny, accurate, fast Express middleware for single page apps with client side routing.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-# ATTENTION, THIS IS JUST A TEMPORARY FORK
-
-I just needed to use callbacks instead of being limited to res.sendFile as I 
-use React server side rendering instead of a static index.html file.
-
 # express-history-api-fallback
 A tiny, accurate, fast Express middleware for single page apps with client side routing.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,9 @@
-export default (...args) => (req, res, next) => {
+export default (fallback, ...args) => (req, res, next) => {
   if (req.method === 'GET' && req.accepts('html')) {
-    res.sendFile(...args, err => err && next())
+    if (fallback instanceof Function) {
+      fallback(req, res, next)
+    } else {
+      res.sendFile(fallback, ...args, err => err && next())
+    }
   } else next()
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "express-history-api-fallback",
+  "name": "@stipsan/express-history-api-fallback",
   "version": "2.1.0",
   "description": "Simple fallback for Express-served single page apps that use the HTML5 History API for client side routing.",
   "main": "./dist",
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cbas/express-history-api-fallback.git"
+    "url": "git+https://github.com/stipsan/express-history-api-fallback.git"
   },
   "keywords": [
     "express",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-history-api-fallback",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Simple fallback for Express-served single page apps that use the HTML5 History API for client side routing.",
   "main": "./dist",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stipsan/express-history-api-fallback",
+  "name": "express-history-api-fallback",
   "version": "2.1.0",
   "description": "Simple fallback for Express-served single page apps that use the HTML5 History API for client side routing.",
   "main": "./dist",
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stipsan/express-history-api-fallback.git"
+    "url": "git+https://github.com/cbas/express-history-api-fallback.git"
   },
   "keywords": [
     "express",

--- a/test/spec.js
+++ b/test/spec.js
@@ -3,6 +3,7 @@
 import fallback from '../lib'
 
 const args = ['index.html', { root: __dirname }]
+const callback = (req, res, next) => res.send()
 
 describe('constructor', () => {
   it('returns something that looks like a middleware', () => {
@@ -12,6 +13,45 @@ describe('constructor', () => {
 })
 
 describe('middleware', () => {
+  const next = sinon.stub()
+  let middleware
+  beforeEach(() => {
+    middleware = fallback(...args)
+  })
+  it('accepts HTML requests', () => {
+    const req = { method: 'GET', accepts: sinon.stub().returns('html') }
+    const res = { sendFile: sinon.stub() }
+    expect(middleware(req, res, next)).to.be.undefined
+    expect(req.accepts).always.have.been.calledWithMatch('html')
+    expect(res.sendFile).always.have.been.calledWithMatch(...args)
+    expect(next).not.to.have.been.called
+  })
+  it('ignores non-HTML requests', () => {
+    const req = { method: 'GET', accepts: sinon.stub().returns('') }
+    const res = { sendFile: sinon.stub() }
+    expect(middleware(req, res, next)).to.be.undefined
+    expect(req.accepts).always.have.been.calledWithMatch('html')
+    expect(res.sendFile).not.to.have.been.called
+    expect(next).to.have.been.called
+  })
+  it('ignores non-GET requests', () => {
+    const req = { method: 'POST', accepts: sinon.stub() }
+    const res = { sendFile: sinon.stub() }
+    expect(middleware(req, res, next)).to.be.undefined
+    expect(req.accepts).not.to.have.been.called
+    expect(res.sendFile).not.to.have.been.called
+    expect(next).to.have.been.called
+  })
+  it('passes on errors if the default file can not be served', () => {
+    const req = { method: 'GET', accepts: sinon.stub().returns('html') }
+    const res = { sendFile: sinon.spy((path, options, callback) => callback(Error)) }
+    expect(middleware(req, res, next)).to.be.undefined
+    expect(req.accepts).always.have.been.calledWithMatch('html')
+    expect(res.sendFile).to.have.been.called
+    expect(next).to.have.been.called
+  })
+})
+describe('middleware with function callback', () => {
   const next = sinon.stub()
   let middleware
   beforeEach(() => {

--- a/test/spec.js
+++ b/test/spec.js
@@ -12,7 +12,7 @@ describe('constructor', () => {
   })
 })
 
-describe('middleware', () => {
+describe('middleware with sendFile', () => {
   const next = sinon.stub()
   let middleware
   beforeEach(() => {
@@ -51,42 +51,35 @@ describe('middleware', () => {
     expect(next).to.have.been.called
   })
 })
-describe('middleware with function callback', () => {
+describe('middleware with callback', () => {
   const next = sinon.stub()
+  const args = [(req, res, next) => res.send()]
   let middleware
   beforeEach(() => {
     middleware = fallback(...args)
   })
   it('accepts HTML requests', () => {
     const req = { method: 'GET', accepts: sinon.stub().returns('html') }
-    const res = { sendFile: sinon.stub() }
+    const res = { send: sinon.stub() }
     expect(middleware(req, res, next)).to.be.undefined
     expect(req.accepts).always.have.been.calledWithMatch('html')
-    expect(res.sendFile).always.have.been.calledWithMatch(...args)
+    expect(res.send).always.have.been.called
     expect(next).not.to.have.been.called
   })
   it('ignores non-HTML requests', () => {
     const req = { method: 'GET', accepts: sinon.stub().returns('') }
-    const res = { sendFile: sinon.stub() }
+    const res = { send: sinon.stub() }
     expect(middleware(req, res, next)).to.be.undefined
     expect(req.accepts).always.have.been.calledWithMatch('html')
-    expect(res.sendFile).not.to.have.been.called
+    expect(res.send).not.to.have.been.called
     expect(next).to.have.been.called
   })
   it('ignores non-GET requests', () => {
     const req = { method: 'POST', accepts: sinon.stub() }
-    const res = { sendFile: sinon.stub() }
+    const res = { send: sinon.stub() }
     expect(middleware(req, res, next)).to.be.undefined
     expect(req.accepts).not.to.have.been.called
-    expect(res.sendFile).not.to.have.been.called
-    expect(next).to.have.been.called
-  })
-  it('passes on errors if the default file can not be served', () => {
-    const req = { method: 'GET', accepts: sinon.stub().returns('html') }
-    const res = { sendFile: sinon.spy((path, options, callback) => callback(Error)) }
-    expect(middleware(req, res, next)).to.be.undefined
-    expect(req.accepts).always.have.been.calledWithMatch('html')
-    expect(res.sendFile).to.have.been.called
+    expect(res.send).not.to.have.been.called
     expect(next).to.have.been.called
   })
 })


### PR DESCRIPTION
Hey, I love the work you've done!

For my own project I was using React to render parts of the server side markup and I didn't have a static index.html file to send the middleware.
This PR adds the possibility of adding your own callback instead of passing arguments to sendFile, allowing you to use the middleware in cases where you don't use a static index.html file for the fallback :)
