### PR TITLE
Support method HEAD

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 export default (...args) => (req, res, next) => {
-  if (req.method === 'GET' && req.accepts('html')) {
+  if ((req.method === 'GET' || req.method === 'HEAD') && req.accepts('html')) {
     res.sendFile(...args, err => err && next())
   } else next()
 }

--- a/test/spec.js
+++ b/test/spec.js
@@ -12,41 +12,48 @@ describe('constructor', () => {
 })
 
 describe('middleware', () => {
+  const methods = ['GET', 'HEAD']
   const next = sinon.stub()
   let middleware
   beforeEach(() => {
     middleware = fallback(...args)
   })
-  it('accepts HTML requests', () => {
-    const req = { method: 'GET', accepts: sinon.stub().returns('html') }
-    const res = { sendFile: sinon.stub() }
-    expect(middleware(req, res, next)).to.be.undefined
-    expect(req.accepts).always.have.been.calledWithMatch('html')
-    expect(res.sendFile).always.have.been.calledWithMatch(...args)
-    expect(next).not.to.have.been.called
+  methods.forEach(method => {
+    it(`accepts ${method} HTML requests`, () => {
+      const req = { method, accepts: sinon.stub().returns('html') }
+      const res = { sendFile: sinon.stub() }
+      expect(middleware(req, res, next)).to.be.undefined
+      expect(req.accepts).always.have.been.calledWithMatch('html')
+      expect(res.sendFile).always.have.been.calledWithMatch(...args)
+      expect(next).not.to.have.been.called
+    })  
   })
-  it('ignores non-HTML requests', () => {
-    const req = { method: 'GET', accepts: sinon.stub().returns('') }
-    const res = { sendFile: sinon.stub() }
-    expect(middleware(req, res, next)).to.be.undefined
-    expect(req.accepts).always.have.been.calledWithMatch('html')
-    expect(res.sendFile).not.to.have.been.called
-    expect(next).to.have.been.called
+  methods.forEach(method => {
+    it(`ignores ${method} non-HTML requests`, () => {
+      const req = { method, accepts: sinon.stub().returns('') }
+      const res = { sendFile: sinon.stub() }
+      expect(middleware(req, res, next)).to.be.undefined
+      expect(req.accepts).always.have.been.calledWithMatch('html')
+      expect(res.sendFile).not.to.have.been.called
+      expect(next).to.have.been.called
+    })
   })
-  it('ignores non-GET requests', () => {
+  methods.forEach(method => {
+    it(`passes on errors if the default file can not be served for ${method} requests`, () => {
+      const req = { method, accepts: sinon.stub().returns('html') }
+      const res = { sendFile: sinon.spy((path, options, callback) => callback(Error)) }
+      expect(middleware(req, res, next)).to.be.undefined
+      expect(req.accepts).always.have.been.calledWithMatch('html')
+      expect(res.sendFile).to.have.been.called
+      expect(next).to.have.been.called
+    })
+  })
+  it('ignores non-GET and non-HEAD requests', () => {
     const req = { method: 'POST', accepts: sinon.stub() }
     const res = { sendFile: sinon.stub() }
     expect(middleware(req, res, next)).to.be.undefined
     expect(req.accepts).not.to.have.been.called
     expect(res.sendFile).not.to.have.been.called
-    expect(next).to.have.been.called
-  })
-  it('passes on errors if the default file can not be served', () => {
-    const req = { method: 'GET', accepts: sinon.stub().returns('html') }
-    const res = { sendFile: sinon.spy((path, options, callback) => callback(Error)) }
-    expect(middleware(req, res, next)).to.be.undefined
-    expect(req.accepts).always.have.been.calledWithMatch('html')
-    expect(res.sendFile).to.have.been.called
     expect(next).to.have.been.called
   })
 })


### PR DESCRIPTION
Following the HTTP specification, we should support method HEAD (basically a GET without body).

That's the same way as https://github.com/expressjs/serve-static handles it (https://github.com/expressjs/serve-static/blob/master/index.js#L73). Just act like it's a normal GET and Express internally will omit the body.